### PR TITLE
Feature/wait for service unbound

### DIFF
--- a/fns/deleteApp.js
+++ b/fns/deleteApp.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 
+const APP_NOT_FOUND = 100004;
+
 module.exports = (api) => {
   return (options, callback) => {
     options = options || {};
@@ -20,7 +22,7 @@ module.exports = (api) => {
       uri: `/v2/apps/${options.appGuid}`
     }, (err, response, result) => {
       var appIdx = -1;
-      if (result && result.code === 100004) {
+      if (result && result.code === APP_NOT_FOUND) {
         appIdx = _.findIndex(api.actualDeploymentConfig.apps, { guid: options.appGuid });
         if (appIdx >= 0) {
           delete api.actualDeploymentConfig.apps[appIdx];
@@ -30,7 +32,7 @@ module.exports = (api) => {
         }
       }
 
-      if (err && !(result && result.code === 100004)) {
+      if (err && !(result && result.code === APP_NOT_FOUND)) {
         return callback(err);
       }
 

--- a/fns/unbindService.js
+++ b/fns/unbindService.js
@@ -51,10 +51,13 @@ module.exports = (api) => {
               _.remove(api.actualDeploymentConfig.serviceBindings, { guid: options.serviceBindingGuid });
             }
 
+            console.log('DELETE SERVICE BINDING', options.serviceBindingGuid);
+
             let attempt = 0;
             (function retry() {
               setTimeout(() => {
                 api.getServiceBinding({ serviceBindingGuid: options.serviceBindingGuid }, (retryError) => {
+                  console.log('CHECKING IF SERVICE IS UNBOUND', options.serviceBindingGuid, retryError.code);
                   if (retryError && SERVICE_NOT_FOUND.includes(retryError.code)) {
                     return callback(null, result);
                   }

--- a/fns/unbindService.js
+++ b/fns/unbindService.js
@@ -68,13 +68,13 @@ module.exports = (api) => {
           }
 
           if (attempt >= retryOptions.maxRetries) {
-            return callback(new Error(`Waiting for service unbind ${options.name || options.serviceBindingGuid} timed out! Most likely a swisscom issue.`));
+            return callback(new Error(`Check if service was successfully unbound ${options.name || options.serviceBindingGuid} timed out! Most likely a swisscom issue.`));
           }
 
           attempt++;
-          debug(`${attempt}. retry for service unbdind ${options.name || options.serviceBindingGuid}`);
+          debug(`${attempt}. retry to check if service was successfully unbound ${options.name || options.serviceBindingGuid}`);
 
-          waitForServiceUnbound();
+          waitForServiceUnbound(serviceBindingGuid, originalResult);
         });
       }, retryOptions.interval * 1000);
     }

--- a/fns/unbindService.js
+++ b/fns/unbindService.js
@@ -3,7 +3,7 @@ const asyncOperationInProgressCheck = require('../lib/graceRequestHandler/asyncO
 const debug = require('debug')('push2cloud-cf-adapter:waitForServiceUnbound');
 
 // CF error for not found service
-//   serviice not found ---vv       vv--- service binding not found
+//   service not found ---vv       vv--- service binding not found
 const SERVICE_NOT_FOUND = [120003, 90004];
 
 module.exports = (api) => {

--- a/fns/waitForAllInstancesRunning.js
+++ b/fns/waitForAllInstancesRunning.js
@@ -32,7 +32,7 @@ module.exports = (api) => {
           if (err) return callback(err);
 
           if (attempt >= options.maxRetries) {
-            return callback(new Error(`${options.name || options.appGuid} timeouted!`));
+            return callback(new Error(`${options.name || options.appGuid} timed out!`));
           }
 
           var running = allInstancesRunning(instances);

--- a/fns/waitForServiceInstance.js
+++ b/fns/waitForServiceInstance.js
@@ -19,7 +19,7 @@ module.exports = (api) => {
           }
 
           if (attempt >= options.maxRetries) {
-            return callback(new Error(`Waiting for service ${options.name || options.serviceInstanceGuid} timeouted!`));
+            return callback(new Error(`Waiting for service ${options.name || options.serviceInstanceGuid} timed out!`));
           }
 
           attempt++;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "push2cloud-cf-adapter",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "abstracts cloud foundry api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Successful delete requests for deleting a service bindings don't result in an _immediate_ callback any more. 
Added a **waitForServiceUnbound** method, which confirms that the service has actually been unbound

Requesting against an unbound service after a delete request which didn't error out, results with an error code 90004, which stands for "CF-ServiceBindingNotFound" which then again seems to be forwarded as "undefined" in the result parameter - hence we can assume that the previous delete call was successfully finished. 

Side changes:
- typo fix
- named error code